### PR TITLE
Provide functions to initiate different kinds of delay streams

### DIFF
--- a/test/persevero_test.gleam
+++ b/test/persevero_test.gleam
@@ -3,10 +3,7 @@ import gleam/option.{None, Some}
 import gleeunit
 import gleeunit/should
 import list_extensions.{at}
-import persevero.{
-  type RetryData, RetriesExhausted, RetryData, UnallowedError, constant_backoff,
-  exponential_backoff, linear_backoff, no_backoff,
-}
+import persevero.{type RetryData, RetriesExhausted, RetryData, UnallowedError}
 
 pub fn main() {
   gleeunit.main()
@@ -36,7 +33,7 @@ pub fn retry_exhausts_all_attempts_and_fails_with_no_backoff_test() {
       Error(InvalidResponse),
     ])
 
-  persevero.new(100, no_backoff)
+  persevero.no_backoff()
   |> persevero.execute_with_wait(
     wait_function: fake_wait,
     allow: fn(_) { True },
@@ -66,7 +63,7 @@ pub fn retry_exhausts_all_attempts_and_fails_with_constant_backoff_test() {
       Error(InvalidResponse),
     ])
 
-  persevero.new(100, constant_backoff)
+  persevero.constant_backoff(100)
   |> persevero.execute_with_wait(
     wait_function: fake_wait,
     allow: fn(_) { True },
@@ -92,7 +89,7 @@ pub fn negative_retry_attempts_returns_retries_exhausted_error_test() {
       Error(InvalidResponse),
     ])
 
-  persevero.new(100, constant_backoff)
+  persevero.constant_backoff(100)
   |> persevero.execute_with_wait(
     wait_function: fake_wait,
     allow: fn(_) { True },
@@ -113,7 +110,7 @@ pub fn no_retry_attempts_returns_retries_exhausted_error_test() {
       Error(InvalidResponse),
     ])
 
-  persevero.new(100, constant_backoff)
+  persevero.constant_backoff(100)
   |> persevero.execute_with_wait(
     wait_function: fake_wait,
     allow: fn(_) { True },
@@ -134,7 +131,7 @@ pub fn one_retry_attempts_returns_retries_exhausted_error_test() {
       Error(InvalidResponse),
     ])
 
-  persevero.new(100, constant_backoff)
+  persevero.constant_backoff(100)
   |> persevero.execute_with_wait(
     wait_function: fake_wait,
     allow: fn(_) { True },
@@ -161,7 +158,7 @@ pub fn retry_exhausts_all_attempts_and_fails_test() {
       Error(InvalidResponse),
     ])
 
-  persevero.new(100, constant_backoff)
+  persevero.constant_backoff(100)
   |> persevero.execute_with_wait(
     wait_function: fake_wait,
     allow: fn(_) { True },
@@ -192,7 +189,7 @@ pub fn retry_fails_on_non_allowed_error_test() {
       Ok(SuccessfulConnection),
     ])
 
-  persevero.new(100, constant_backoff)
+  persevero.constant_backoff(100)
   |> persevero.execute_with_wait(
     wait_function: fake_wait,
     allow: fn(error) {
@@ -226,7 +223,7 @@ pub fn retry_succeeds_on_allowed_errors_test() {
       Error(InvalidResponse),
     ])
 
-  persevero.new(100, constant_backoff)
+  persevero.constant_backoff(100)
   |> persevero.execute_with_wait(
     wait_function: fake_wait,
     allow: fn(error) {
@@ -258,7 +255,7 @@ pub fn retry_succeeds_when_all_errors_are_allowed_test() {
       Ok(ValidData),
     ])
 
-  persevero.new(100, constant_backoff)
+  persevero.constant_backoff(100)
   |> persevero.execute_with_wait(
     wait_function: fake_wait,
     allow: fn(_) { True },
@@ -285,7 +282,7 @@ pub fn retry_succeeds_on_allowed_errors_apply_constant_after_max_wait_time_test(
       Error(InvalidResponse),
     ])
 
-  persevero.new(50, exponential_backoff(_, 2))
+  persevero.exponential_backoff(50, 2)
   |> persevero.max_wait_time(100)
   |> persevero.apply_constant(3)
   |> persevero.execute_with_wait(
@@ -319,7 +316,7 @@ pub fn retry_succeeds_on_allowed_errors_apply_constant_before_max_wait_time_test
       Error(InvalidResponse),
     ])
 
-  persevero.new(50, exponential_backoff(_, 2))
+  persevero.exponential_backoff(50, 2)
   |> persevero.apply_constant(3)
   |> persevero.max_wait_time(100)
   |> persevero.execute_with_wait(
@@ -353,7 +350,7 @@ pub fn retry_with_exponential_backoff_test() {
       Ok(ValidData),
     ])
 
-  persevero.new(100, exponential_backoff(_, 2))
+  persevero.exponential_backoff(100, 2)
   |> persevero.execute_with_wait(
     wait_function: fake_wait,
     allow: fn(_) { True },
@@ -380,7 +377,7 @@ pub fn retry_with_linear_backoff_test() {
       Ok(ValidData),
     ])
 
-  persevero.new(100, linear_backoff(_, 100))
+  persevero.linear_backoff(100, 100)
   |> persevero.execute_with_wait(
     wait_function: fake_wait,
     allow: fn(_) { True },
@@ -407,9 +404,7 @@ pub fn retry_with_custom_backoff_test() {
       Ok(ValidData),
     ])
 
-  persevero.new(100, fn(wait) {
-    wait |> linear_backoff(100) |> exponential_backoff(2)
-  })
+  persevero.custom_backoff(100, fn(acc) { { acc + 100 } * 2 })
   |> persevero.execute_with_wait(
     wait_function: fake_wait,
     allow: fn(_) { True },
@@ -436,7 +431,7 @@ pub fn retry_with_backoff_succeeds_after_allowed_errors_test() {
       Error(InvalidResponse),
     ])
 
-  persevero.new(100, exponential_backoff(_, 3))
+  persevero.exponential_backoff(100, 3)
   |> persevero.execute_with_wait(
     wait_function: fake_wait,
     allow: fn(error) {
@@ -468,7 +463,7 @@ pub fn retry_with_negative_wait_time_configuration_test() {
       Error(InvalidResponse),
     ])
 
-  persevero.new(-100, linear_backoff(_, -1000))
+  persevero.linear_backoff(-100, -1000)
   |> persevero.execute_with_wait(
     wait_function: fake_wait,
     allow: fn(_) { True },
@@ -499,7 +494,7 @@ pub fn retry_with_max_wait_time_configuration_test() {
       Error(InvalidResponse),
     ])
 
-  persevero.new(500, exponential_backoff(_, 2))
+  persevero.exponential_backoff(500, 2)
   |> persevero.max_wait_time(1000)
   |> persevero.execute_with_wait(
     wait_function: fake_wait,


### PR DESCRIPTION
This is a breaking change, we no longer begin the process with `new`. `new` was overloaded, and [hacks](https://github.com/JosephTLyons/persevero/commit/b838108b585dc67045e567e5c9c5f68e5920c781#diff-3416a51d9a70208f7e52a3917527ba40fa903b8ad7d5057e4530ff90d7d249a7R63) were needed to make it work correctly with the different types of delay stream generator.